### PR TITLE
feat: add devcontainer

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,1 +1,0 @@
-FROM mcr.microsoft.com/vscode/devcontainers/javascript-node

--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,1 @@
+FROM mcr.microsoft.com/vscode/devcontainers/javascript-node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,17 @@
+{
+  "build": {
+    "dockerfile": "Dockerfile"
+  },
+  "customizations": {
+    "codespaces": {
+      "repositories": {
+        "pi-base/data": {
+          "permissions": {
+            "contents": "read"
+          }
+        }
+      }
+    }
+  },
+  "postCreateCommand": "git clone git@github.com:pi-base/data.git /workspaces/data"
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,9 +1,12 @@
 {
-  "build": {
-    "dockerfile": "Dockerfile"
-  },
+  "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node",
+  "onCreateCommand": "pnpm install && pnpm run --filter core build",
+  "postCreateCommand": "git clone https://github.com/pi-base/data.git /workspaces/data",
   "customizations": {
     "codespaces": {
+      "openFiles": [
+        "doc/codespaces/welcome.md"
+      ],
       "repositories": {
         "pi-base/data": {
           "permissions": {
@@ -11,7 +14,10 @@
           }
         }
       }
+    },
+    "vscode": {
+      "extensions": [],
+      "settings": {}
     }
-  },
-  "postCreateCommand": "git clone git@github.com:pi-base/data.git /workspaces/data"
+  }
 }

--- a/doc/codespaces/welcome.md
+++ b/doc/codespaces/welcome.md
@@ -1,0 +1,28 @@
+🎉 Welcome to your Codespace
+
+# Compiling a bundle locally
+
+```bash
+# Start a server that listens for changes to /workspaces/data, builds a bundle
+# and serves it compatibly with the production S3 backend.
+/workspaces/web $ pnpm run --filter compile dev
+```
+
+Verify that the server is working by opening another terminal in the codespace
+and running
+
+```bash
+$ curl -s localhost:3141/refs/heads/master | jq '.version'
+```
+
+## Troubleshooting
+
+### Cannot find module '@pi-base/core'
+
+The `@pi-base/core` package is expected to be built and available in the local
+workspace. It should be pre-built when the workspace is created, but you can
+rebuild it with.
+
+```bash
+/workspaces/web $ pnpm run --filter core build
+```

--- a/packages/compile/src/load.ts
+++ b/packages/compile/src/load.ts
@@ -19,7 +19,7 @@ export default async function load(
     spaces: await readFiles(`${repo}/spaces/*/README.md`),
     theorems: await readFiles(`${repo}/theorems/*.md`),
     traits: await readFiles(`${repo}/spaces/*/properties/*.md`),
-    version: await findVersion(),
+    version: await findVersion(repo),
   })
 }
 

--- a/packages/compile/src/main.ts
+++ b/packages/compile/src/main.ts
@@ -1,3 +1,8 @@
+/**
+ * Entry point for running as a Github action, with the local workspace
+ * containing the data repository. Set GITHUB_WORKSPACE to use a different
+ * data repository.
+ */
 import * as core from '@actions/core'
 import * as fs from 'fs'
 import * as process from 'process'
@@ -5,12 +10,8 @@ import { bundle as B } from '@pi-base/core'
 
 import load from './load.js'
 
-function error(file: string, message: string) {
-  console.log(`::error file=${file}::${message}`)
-}
-
 async function run(): Promise<void> {
-  const repo: string = process.env['GITHUB_WORKSPACE'] || '.'
+  const repo: string = process.env.GITHUB_WORKSPACE || '.'
   const outpath: string = core.getInput('out')
 
   core.debug(`Compiling repo=${repo} to out=${outpath}`)
@@ -31,6 +32,10 @@ async function run(): Promise<void> {
   }
 
   fs.writeFileSync(outpath, JSON.stringify(B.serialize(bundle)))
+}
+
+function error(file: string, message: string) {
+  console.log(`::error file=${file}::${message}`)
 }
 
 run().catch((err) => {

--- a/packages/compile/src/validations.ts
+++ b/packages/compile/src/validations.ts
@@ -1,4 +1,4 @@
-import * as yaml from 'yaml-front-matter'
+import yaml from 'yaml-front-matter'
 
 import { Bundle, Property, formula as Formula } from '@pi-base/core'
 

--- a/packages/compile/src/version.ts
+++ b/packages/compile/src/version.ts
@@ -1,4 +1,5 @@
 import { Version } from '@pi-base/core'
+import { resolve } from 'node:path'
 
 import { readFile } from './fs.js'
 
@@ -7,8 +8,8 @@ function refName(raw: string) {
   return match && match[1]
 }
 
-export async function find() {
-  let version = await fromRepo()
+export async function find(root = '.') {
+  let version = await fromRepo(root)
   if (version) {
     return version
   }
@@ -21,8 +22,8 @@ export async function find() {
   throw new Error('Could not determine bundle version')
 }
 
-async function fromRepo(): Promise<Version | undefined> {
-  const contents = await readFile('.git/HEAD').catch(() => { })
+async function fromRepo(root = '.'): Promise<Version | undefined> {
+  const contents = await readFile(resolve(root, '.git', 'HEAD')).catch(() => { })
   if (!contents) {
     return
   }
@@ -30,7 +31,7 @@ async function fromRepo(): Promise<Version | undefined> {
   const head = refName(contents)
 
   if (head) {
-    const sha = await readFile(`.git/refs/heads/${head}`)
+    const sha = await readFile(resolve(root, '.git', 'refs', 'heads', head))
     return {
       ref: head,
       sha: sha.trim(),

--- a/packages/compile/src/watch.ts
+++ b/packages/compile/src/watch.ts
@@ -1,11 +1,22 @@
+/**
+ * Watch DATA_WORKSPACE (../data) for changes, (re)build an serve a data bundle
+ * locally at PORT (3141).
+ *
+ * Intended for running locally while iterating on changes in the data repo.
+ */
 import chalk from 'chalk'
+import { fileURLToPath } from 'node:url'
+import { dirname, resolve } from 'node:path'
 
 import load from './load.js'
 import listen from './watch/listen.js'
 import { boot } from './watch/server.js'
 
-const port = 3141
-const root = process.cwd()
+const dir = dirname(fileURLToPath(import.meta.url))
+const root = resolve(dir, '..', '..', '..')
+const data = process.env.DATA_WORKSPACE || resolve(root, '..', 'data')
+
+const port = Number(process.env.PORT || '3141')
 
 const { cyan, green, red, yellow } = chalk
 
@@ -15,7 +26,7 @@ const { setState } = boot({ log, port })
 
 async function build() {
   try {
-    const { bundle, errors } = await load('.')
+    const { bundle, errors } = await load(data)
 
     if (!bundle) {
       log(red('Build failed'))
@@ -26,13 +37,13 @@ async function build() {
     }
 
     if (errors) {
-      log('')
+      log()
       for (const [path, messages] of errors) {
         log(yellow(path))
         for (const message of messages) {
           log(`* ${message}`)
         }
-        log('')
+        log()
       }
     }
 
@@ -42,10 +53,10 @@ async function build() {
   }
 }
 
-log(`Watching ${cyan(root)} for changes.`)
+log(`Watching ${cyan(data)} for changes.`)
 log(`Press ${cyan('CTRL-C')} to exit.`)
 
-listen(root, (path: string) => {
+listen(data, (path: string) => {
   log(`${cyan(path)} changed. Re-compiling.`)
   build()
 })

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -60,11 +60,9 @@ importers:
   packages/core:
     specifiers:
       '@types/unist': ^2.0.3
-      js-yaml: ^4.1.0
       peggy: ^2.0.1
       remark: ^14.0.2
       remark-rehype: ^10.1.0
-      rollup-plugin-peggy: ^3.0.0
       ts-pegjs: ^2.1.0
       unified: ^10.1.2
       unist-util-visit: ^4.1.1
@@ -75,9 +73,7 @@ importers:
       unist-util-visit: 4.1.1
     devDependencies:
       '@types/unist': 2.0.6
-      js-yaml: 4.1.0
       peggy: 2.0.1
-      rollup-plugin-peggy: 3.0.0
       ts-pegjs: 2.1.0_peggy@2.0.1
 
   packages/viewer:
@@ -1763,6 +1759,7 @@ packages:
 
   /argparse/2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+    dev: false
 
   /arr-diff/4.0.0:
     resolution: {integrity: sha512-YVIQ82gZPGBebQV/a8dar4AitzCQs0jjXwMPZllpXMaGjXPYVUawSxQrRsjhjupyVxEvbHgUmIhKVlND+j02kA==}
@@ -5008,6 +5005,7 @@ packages:
     hasBin: true
     dependencies:
       argparse: 2.0.1
+    dev: false
 
   /jsbn/0.1.1:
     resolution: {integrity: sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==}
@@ -6230,12 +6228,6 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
-  /peggy/1.2.0:
-    resolution: {integrity: sha512-PQ+NKpAobImfMprYQtc4Egmyi29bidRGEX0kKjCU5uuW09s0Cthwqhfy7mLkwcB4VcgacE5L/ZjruD/kOPCUUw==}
-    engines: {node: '>=10'}
-    hasBin: true
-    dev: true
-
   /peggy/2.0.1:
     resolution: {integrity: sha512-mBqfmdUAOVn7RILpXTbcRBhLfTR4Go0SresSnivGDdRylBOyVFJncFiVyCNNpPWq8HmgeRleXHs/Go4o8kQVXA==}
     engines: {node: '>=10'}
@@ -6802,13 +6794,6 @@ packages:
     resolution: {integrity: sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==}
     dependencies:
       rollup-plugin-inject: 3.0.2
-    dev: true
-
-  /rollup-plugin-peggy/3.0.0:
-    resolution: {integrity: sha512-nRfWeob8fAnXFgaEi6F0nW7dRVkglQtSdpQmynUAFZRSfM6069k0dC+Hgc+OKt9C9Qz1uEjywpO5g5dC44uOhw==}
-    dependencies:
-      peggy: 1.2.0
-      rollup-pluginutils: 2.8.2
     dev: true
 
   /rollup-plugin-svelte/6.1.1_himpnf5456wzehbj5dj5u7v4ri:


### PR DESCRIPTION
Gets a `devcontainer` set up to the point where the out-of-the box codespace can easily run `compile`'s `dev` mode and watch the local `data` repo for changes.