### PR TITLE
feat: start server on attaching

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,9 @@
 {
   "image": "mcr.microsoft.com/vscode/devcontainers/javascript-node",
   "onCreateCommand": "pnpm install && pnpm run --filter core build",
+  "postAttachCommand": {
+    "compile": "pnpm run --filter compile dev"
+  },
   "postCreateCommand": "git clone https://github.com/pi-base/data.git /workspaces/data",
   "customizations": {
     "codespaces": {

--- a/doc/codespaces/welcome.md
+++ b/doc/codespaces/welcome.md
@@ -2,20 +2,24 @@
 
 # Compiling a bundle locally
 
-```bash
-# Start a server that listens for changes to /workspaces/data, builds a bundle
-# and serves it compatibly with the production S3 backend.
-/workspaces/web $ pnpm run --filter compile dev
-```
+Your codespace starts a `compile process` process which watches
+`/workspaces/data` and serves its contents at `localhost:3141/refs/heads/(:branch)`,
+consistent with the production S3 API.
 
-Verify that the server is working by opening another terminal in the codespace
-and running
+Once the server has started and the first build has finished, you can verify the
+result by running
 
 ```bash
 $ curl -s localhost:3141/refs/heads/master | jq '.version'
 ```
 
 ## Troubleshooting
+
+### Starting the compile process manually
+
+```bash
+/workspaces/web $ pnpm run --filter compile dev
+```
 
 ### Cannot find module '@pi-base/core'
 


### PR DESCRIPTION
Ensures the `compile` watcher process auto-starts when the codespace is created.