### PR TITLE
get the viewer bootable

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -4,6 +4,9 @@
   "postAttachCommand": {
     "compile": "pnpm run --filter compile dev"
   },
+  "forwardPorts": [
+    8080
+  ],
   "postCreateCommand": "git clone https://github.com/pi-base/data.git /workspaces/data",
   "customizations": {
     "codespaces": {

--- a/doc/codespaces/welcome.md
+++ b/doc/codespaces/welcome.md
@@ -13,6 +13,17 @@ result by running
 $ curl -s localhost:3141/refs/heads/master | jq '.version'
 ```
 
+# Running the viewer
+
+```bash
+# in packages/viewer
+# compile .js and .css assets
+npm run build
+
+# serve assets and expose them externally
+npm run start --host
+```
+
 ## Troubleshooting
 
 ### Starting the compile process manually

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -29,12 +29,13 @@
     "remark": "^14.0.2",
     "remark-rehype": "^10.1.0",
     "unified": "^10.1.2",
+    "unist-util-is": "^5.2.1",
     "unist-util-visit": "^4.1.2",
     "zod": "^3.21.3"
   },
   "devDependencies": {
     "@types/unist": "^2.0.3",
-    "peggy": "^3.0.1",
+    "peggy": "^2.0.1",
     "ts-pegjs": "^3.1.0"
   }
 }

--- a/packages/viewer/package.json
+++ b/packages/viewer/package.json
@@ -17,16 +17,19 @@
   "dependencies": {
     "@pi-base/core": "workspace:0.4.0",
     "@sentry/browser": "^7.41.0",
-    "bootstrap": "^5.2.3",
+    "bootstrap": "^4.6.2",
     "fromnow": "^3.0.1",
     "fuse.js": "^6.4.1",
     "hast-to-hyperscript": "^10.0.3",
     "hyperscript": "^2.0.2",
+    "jquery": "1.9.1",
+    "popper.js": "^1.16.1",
     "rehype-katex": "^6.0.2",
     "remark-rehype": "^10.1.0",
     "sirv-cli": "^2.0.2",
     "svelte-routing": "^1.4.2",
     "unified": "^10.1.2",
+    "unist-util-is": "^5.2.1",
     "unist-util-visit": "^4.1.2"
   },
   "devDependencies": {

--- a/packages/viewer/src/models/Theorems.ts
+++ b/packages/viewer/src/models/Theorems.ts
@@ -1,7 +1,8 @@
 import { formula as F } from '@pi-base/core'
 
 import Collection from './Collection'
-import { type Property, Theorem, type SerializedTheorem } from '../models'
+import { default as Theorem } from './Theorem'
+import type { Property, SerializedTheorem } from '../types'
 
 export default class Theorems {
   static build(

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -70,23 +70,25 @@ importers:
   packages/core:
     specifiers:
       '@types/unist': ^2.0.3
-      peggy: ^3.0.1
+      peggy: ^2.0.1
       remark: ^14.0.2
       remark-rehype: ^10.1.0
       ts-pegjs: ^3.1.0
       unified: ^10.1.2
+      unist-util-is: ^5.2.1
       unist-util-visit: ^4.1.2
       zod: ^3.21.3
     dependencies:
       remark: 14.0.2
       remark-rehype: 10.1.0
       unified: 10.1.2
+      unist-util-is: 5.2.1
       unist-util-visit: 4.1.2
       zod: 3.21.3
     devDependencies:
       '@types/unist': 2.0.6
-      peggy: 3.0.1
-      ts-pegjs: 3.1.0_peggy@3.0.1
+      peggy: 2.0.1
+      ts-pegjs: 3.1.0_peggy@2.0.1
 
   packages/viewer:
     specifiers:
@@ -102,12 +104,14 @@ importers:
       '@types/katex': ^0.16.0
       '@types/page': ^1.8.0
       '@types/unist': ^2.0.3
-      bootstrap: ^5.2.3
+      bootstrap: ^4.6.2
       cypress: ^12.7.0
       fromnow: ^3.0.1
       fuse.js: ^6.4.1
       hast-to-hyperscript: ^10.0.3
       hyperscript: ^2.0.2
+      jquery: 1.9.1
+      popper.js: ^1.16.1
       rehype-katex: ^6.0.2
       remark-rehype: ^10.1.0
       rollup: ^3.18.0
@@ -125,22 +129,26 @@ importers:
       tslib: ^2.5.0
       typescript: ^4.9.5
       unified: ^10.1.2
+      unist-util-is: ^5.2.1
       unist-util-visit: ^4.1.2
       vitest: ^0.29.2
       wait-on: ^7.0.1
     dependencies:
       '@pi-base/core': link:../core
       '@sentry/browser': 7.41.0
-      bootstrap: 5.2.3
+      bootstrap: 4.6.2_dykjst3bd6egbdjucaxta7phyq
       fromnow: 3.0.1
       fuse.js: 6.6.2
       hast-to-hyperscript: 10.0.3
       hyperscript: 2.0.2
+      jquery: 1.9.1
+      popper.js: 1.16.1
       rehype-katex: 6.0.2
       remark-rehype: 10.1.0
       sirv-cli: 2.0.2
       svelte-routing: 1.6.0_4x7phaipmicbaooxtnresslofa
       unified: 10.1.2
+      unist-util-is: 5.2.1
       unist-util-visit: 4.1.2
     devDependencies:
       '@rollup/plugin-commonjs': 24.0.1_rollup@3.18.0
@@ -1042,10 +1050,14 @@ packages:
       - supports-color
     dev: true
 
-  /bootstrap/5.2.3:
-    resolution: {integrity: sha512-cEKPM+fwb3cT8NzQZYEu4HilJ3anCrWqh3CHAok1p9jXqMPsPTBhU25fBckEJHJ/p+tTxTFTsFQGM+gaHpi3QQ==}
+  /bootstrap/4.6.2_dykjst3bd6egbdjucaxta7phyq:
+    resolution: {integrity: sha512-51Bbp/Uxr9aTuy6ca/8FbFloBUJZLHwnhTcnjIeRn2suQWsWzcuJhGjKDB5eppVte/8oCdOL3VuwxvZDUggwGQ==}
     peerDependencies:
-      '@popperjs/core': ^2.11.6
+      jquery: 1.9.1 - 3
+      popper.js: ^1.16.1
+    dependencies:
+      jquery: 1.9.1
+      popper.js: 1.16.1
     dev: false
 
   /brace-expansion/1.1.11:
@@ -1298,11 +1310,6 @@ packages:
     resolution: {integrity: sha512-Fu4hJdvzeylCfQPp9SGWidpzrMs7tTrlu6Vb8XGaRGck8QSNZJJp538Wrb60Lax4fPwR64ViY468OIUTbRlGZg==}
     dev: false
 
-  /commander/10.0.0:
-    resolution: {integrity: sha512-zS5PnTI22FIRM6ylNW8G4Ap0IEOyk62fhLSD0+uHRT9McRCLGpkVNvao4bjimpK/GShynyQkFFxHhwMcETmduA==}
-    engines: {node: '>=14'}
-    dev: true
-
   /commander/5.1.0:
     resolution: {integrity: sha512-P0CysNDQ7rtVw4QIQtm+MRxV66vKFSvlsQvGYXZWR3qFU0jlMKHZZZgw8e+8DSah4UDKMqnknRDQz+xuQXQ/Zg==}
     engines: {node: '>= 6'}
@@ -1317,6 +1324,11 @@ packages:
     resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
     engines: {node: '>= 12'}
     dev: false
+
+  /commander/9.5.0:
+    resolution: {integrity: sha512-KRs7WVDKg86PWiuAqhDrAQnTXZKraVcCc6vFdL14qrZ/DcWwuRo7VoiYXalXO7S5GKpqYiVEwCbgFDfxNHKJBQ==}
+    engines: {node: ^12.20.0 || >=14}
+    dev: true
 
   /common-tags/1.8.2:
     resolution: {integrity: sha512-gk/Z852D2Wtb//0I+kRFNKKE9dIIVirjoqPoA1wJU+XePVXZfGeBpk45+A1rKO4Q43prqWBNY/MiIeRLbPWUaA==}
@@ -2588,6 +2600,10 @@ packages:
       '@sideway/pinpoint': 2.0.0
     dev: true
 
+  /jquery/1.9.1:
+    resolution: {integrity: sha1-5M1INfqu+63lNYV2E8D8P/KtrzQ=}
+    dev: false
+
   /js-tokens/4.0.0:
     resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
     dev: true
@@ -3318,12 +3334,12 @@ packages:
     resolution: {integrity: sha512-Dp6zGqpTdETdR63lehJYPeIOqpiNBNtc7BpWSLrOje7UaIsE5aY92r/AunQA7rsXvet3lrJ3JnZX29UPTKXyKQ==}
     dev: true
 
-  /peggy/3.0.1:
-    resolution: {integrity: sha512-opG0pnfH5ZQvlqz8Ozmk1SvIer9Rz6op0nDSkVQ4kQnVL0+KOKtIocoidxOgpLoS82r+ZW8J16FjhL3rhH/MpA==}
-    engines: {node: '>=14'}
+  /peggy/2.0.1:
+    resolution: {integrity: sha512-mBqfmdUAOVn7RILpXTbcRBhLfTR4Go0SresSnivGDdRylBOyVFJncFiVyCNNpPWq8HmgeRleXHs/Go4o8kQVXA==}
+    engines: {node: '>=10'}
     hasBin: true
     dependencies:
-      commander: 10.0.0
+      commander: 9.5.0
       source-map-generator: 0.8.0
     dev: true
 
@@ -3355,6 +3371,11 @@ packages:
       mlly: 1.1.1
       pathe: 1.1.0
     dev: true
+
+  /popper.js/1.16.1:
+    resolution: {integrity: sha512-Wb4p1J4zyFTbM+u6WuO4XstYx4Ky9Cewe4DWrel7B0w6VVICvPwdOpotjzcf6eD8TsckVnIMNONQyPIUFOUbCQ==}
+    deprecated: You can find the new Popper v2 at @popperjs/core, this package is dedicated to the legacy v1
+    dev: false
 
   /postcss/8.4.19:
     resolution: {integrity: sha512-h+pbPsyhlYj6N2ozBmHhHrs9DzGmbaarbLvWipMRO7RLS+v4onj26MPFXA5OBYFxyqYhUJK456SwDcY9H2/zsA==}
@@ -4356,13 +4377,13 @@ packages:
       yn: 3.1.1
     dev: true
 
-  /ts-pegjs/3.1.0_peggy@3.0.1:
+  /ts-pegjs/3.1.0_peggy@2.0.1:
     resolution: {integrity: sha512-CZ80MYdzoh/setHAcrOdWh7ws4GsIPAahFEZ1019xPLe2snSzwuCLDAwQ0r7xHLIuOuRJ7v87jvz/Lr5YTLN4g==}
     hasBin: true
     peerDependencies:
       peggy: ^2.0.1
     dependencies:
-      peggy: 3.0.1
+      peggy: 2.0.1
     dev: true
 
   /tsheredoc/1.0.1:
@@ -4450,15 +4471,17 @@ packages:
     resolution: {integrity: sha512-QO/PuPMm2ERxC6vFXEPtmAutOopy5PknD+Oq64gGwxKtk4xwo9Z97t9Av1obPmGU0IyTa6EKYUfTrK2QJS3Ozw==}
     dependencies:
       '@types/unist': 2.0.6
-      unist-util-is: 5.1.1
+      unist-util-is: 5.2.1
     dev: false
 
   /unist-util-generated/2.0.0:
     resolution: {integrity: sha512-TiWE6DVtVe7Ye2QxOVW9kqybs6cZexNwTwSMVgkfjEReqy/xwGpAXb99OxktoWwmL+Z+Epb0Dn8/GNDYP1wnUw==}
     dev: false
 
-  /unist-util-is/5.1.1:
-    resolution: {integrity: sha512-F5CZ68eYzuSvJjGhCLPL3cYx45IxkqXSetCcRgUXtbcm50X2L9oOWQlfUfDdAf+6Pd27YDblBfdtmsThXmwpbQ==}
+  /unist-util-is/5.2.1:
+    resolution: {integrity: sha512-u9njyyfEh43npf1M+yGKDGVPbY/JWEemg5nH05ncKPfi+kBbKBJoTdsogMu33uhytuLlv9y0O7GH7fEdwLdLQw==}
+    dependencies:
+      '@types/unist': 2.0.6
     dev: false
 
   /unist-util-position/4.0.3:
@@ -4484,14 +4507,14 @@ packages:
     resolution: {integrity: sha512-gks4baapT/kNRaWxuGkl5BIhoanZo7sC/cUT/JToSRNL1dYoXRFl75d++NkjYk4TAu2uv2Px+l8guMajogeuiw==}
     dependencies:
       '@types/unist': 2.0.6
-      unist-util-is: 5.1.1
+      unist-util-is: 5.2.1
     dev: false
 
   /unist-util-visit/4.1.2:
     resolution: {integrity: sha512-MSd8OUGISqHdVvfY9TPhyK2VdUrPgxkUtWSuMHF6XAAFuL4LokseigBnZtPnJMu+FbynTkFNnFlyjxpVKujMRg==}
     dependencies:
       '@types/unist': 2.0.6
-      unist-util-is: 5.1.1
+      unist-util-is: 5.2.1
       unist-util-visit-parents: 5.1.1
     dev: false
 


### PR DESCRIPTION
Progress on launching the `viewer` in a Codespace:

<img width="1221" alt="Screenshot 2023-03-06 at 5 09 30 PM" src="https://user-images.githubusercontent.com/1079270/223293342-f0d5b351-e6c2-4c4e-80f6-6b677ce4fd2c.png">

Some key parts are still non-functional - notably, fetching the bundle, and parsing math / descriptions.