### PR TITLE
fix: viewer dev server

### DIFF
--- a/packages/viewer/rollup.config.mjs
+++ b/packages/viewer/rollup.config.mjs
@@ -10,6 +10,7 @@ import typescript from '@rollup/plugin-typescript';
 import replace from '@rollup/plugin-replace';
 import css from 'rollup-plugin-css-only';
 import copy from 'rollup-plugin-copy';
+import { spawn } from 'node:child_process';
 
 const production = !process.env.ROLLUP_WATCH;
 
@@ -23,7 +24,7 @@ function serve() {
 	return {
 		writeBundle() {
 			if (server) return;
-			server = require('child_process').spawn('npm', ['run', 'start', '--', '--dev'], {
+			server = spawn('npm', ['run', 'start', '--', '--dev'], {
 				stdio: ['ignore', 'inherit', 'inherit'],
 				shell: true
 			});


### PR DESCRIPTION
moving to .mjs broke the dynamic require used in dev mode.

With this

```bash
packages/viewer $ pnpm run dev
```

should rebuild and re-serve on changes