### PR TITLE
feat: restore truncation during parsing

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -1,9 +1,9 @@
-name: test
+name: lint
 on:
   push:
 
 jobs:
-  test:
+  lint:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -26,6 +26,7 @@
     "test": "vitest"
   },
   "dependencies": {
+    "debug": "^4.3.4",
     "mdast": "^3.0.0",
     "micromark-util-types": "^1.0.2",
     "rehype-katex": "^6.0.2",
@@ -40,6 +41,8 @@
     "zod": "3.20.1"
   },
   "devDependencies": {
+    "@types/debug": "^4.1.7",
+    "@types/mdast": "^3.0.11",
     "@types/unist": "^2.0.3",
     "hast-util-to-html": "^8.0.4",
     "mdast-util-from-markdown": "^1.3.0",

--- a/packages/core/src/Parser.ts
+++ b/packages/core/src/Parser.ts
@@ -8,19 +8,31 @@ import rehypeStringify from 'rehype-stringify'
 
 import { links } from './Parser/links.js'
 import { unnest } from './Parser/unnest.js'
+import { truncation } from './Parser/truncation.js'
+
+function noOp() {
+  return (tree: Node) => tree
+}
+
+export type Options = {
+  link?: boolean
+  truncate?: boolean
+}
 
 /**
  * Full parser chain translating Markdown to HTML, including rendering math and
  * custom π-base syntax extensions.
  */
-export function parser(
+export function parser({
   link = true,
-): Processor<Node<Data>, Node<Data>, Node<Data>, void> {
+  truncate = false,
+}: Partial<Options> = {}): Processor<Node<Data>, Node<Data>, Node<Data>, void> {
   return unified()
     .use(remarkParse)
-    .use(link ? links : () => x => x) // FIXME
+    .use(link ? links : noOp)
     .use(unnest)
     .use(remarkMath)
+    .use(truncate ? truncation : noOp)
     .use(remarkRehype)
     .use(rehypeKatex)
     .use(rehypeStringify)

--- a/packages/core/src/Parser/truncation.ts
+++ b/packages/core/src/Parser/truncation.ts
@@ -1,11 +1,7 @@
-import type * as unist from 'unist'
+import { Root, Content } from 'mdast'
+import { Transformer } from 'unified'
 
-type Node = unist.Node & {
-  children?: Node[]
-  value?: string
-}
-
-function gather(nodes: Node[], to: number) {
+function gather(nodes: Content[], to: number) {
   let length = 0
   const acc = []
 
@@ -37,10 +33,18 @@ function gather(nodes: Node[], to: number) {
   return acc
 }
 
-export default function truncate(to = 100) {
-  return function transformer(tree: Node) {
-    const node = (tree.children || [])[0] || {}
+export function truncation(to = 100): Transformer<Root, Root> {
+  return function transformer(tree: Root) {
+    const node = tree.children[0] || {}
 
-    return { ...node, children: gather(node.children || [], to) }
+    if ('children' in node) {
+      return {
+        ...node,
+        type: 'root',
+        children: gather(node.children, to),
+      } as Root
+    } else {
+      return { ...node, type: 'root' } as Root
+    }
   }
 }

--- a/packages/viewer/index.html
+++ b/packages/viewer/index.html
@@ -24,8 +24,6 @@
 
 	<link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/katex@0.16.0/dist/katex.min.css" integrity="sha384-Xi8rHCmBmhbuyyhbI88391ZKP2dmfnOl4rT9ZfRI7mLTdk1wblIUnrIq35nqwEvC" crossorigin="anonymous">
 	<link rel='stylesheet' href='/global.css'>
-	<link rel='stylesheet' href='/build/vendor.css'>
-	<link rel='stylesheet' href='/build/bundle.css'>
 
 	<script type="module" src="/src/main.ts"></script>
 </head>

--- a/packages/viewer/src/components/Dev/Preview.svelte
+++ b/packages/viewer/src/components/Dev/Preview.svelte
@@ -19,15 +19,17 @@
           type="checkbox"
           bind:checked={truncated}
           class="form-check-input"
-          id="truncated" />
+          id="truncated"
+        />
         <label class="form-check-label" for="truncated"> Truncated </label>
       </div>
     </div>
 
     <Example
-      set={(value) => {
+      set={value => {
         body = value
-      }} />
+      }}
+    />
   </div>
   <div class="col-sm">
     <Typeset {body} {truncated} />

--- a/packages/viewer/src/components/Shared/Typeset.svelte
+++ b/packages/viewer/src/components/Shared/Typeset.svelte
@@ -3,18 +3,19 @@
   import { render as renderer } from './render-utils'
 
   export let body: string
+  export let truncated = false
 
   let container: HTMLElement
 
-  async function render(text: string) {
+  async function render(text: string, truncated_: boolean) {
     if (container) {
-      container.innerHTML = await renderer(text)
+      container.innerHTML = await renderer(text, truncated_)
     }
   }
 
-  onMount(() => render(body))
+  onMount(() => render(body, truncated))
 
-  $: render(body)
+  $: render(body, truncated)
 </script>
 
 <span bind:this={container} />

--- a/packages/viewer/src/components/Shared/render-utils.ts
+++ b/packages/viewer/src/components/Shared/render-utils.ts
@@ -1,14 +1,13 @@
 import { parser } from '@pi-base/core'
-// TODO
-// import { truncate } from './Display'
 
-const full = parser(false)
-// const truncated = parser().use([truncate])
+const link = true // FIXME
+const full = parser({ link, truncate: false })
+const truncated = parser({ link, truncate: true })
 
 export async function render(body: string, truncate: boolean = false) {
-  // const parser = truncate ? truncated : full
-  const parser = full
+  const parser = truncate ? truncated : full
 
+  console.log('Rendering', body)
   const file = await parser.process(body)
 
   return String(file)

--- a/packages/viewer/src/components/Spaces/Show.svelte
+++ b/packages/viewer/src/components/Spaces/Show.svelte
@@ -15,7 +15,7 @@
   export let id: string
 
   const ctx = context()
-  const load = ctx.load(ctx.spaces, (s) => s.find(id))
+  const load = ctx.load(ctx.spaces, s => s.find(id))
 </script>
 
 {#await load}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -98,6 +98,9 @@ importers:
 
   packages/core:
     dependencies:
+      debug:
+        specifier: ^4.3.4
+        version: 4.3.4(supports-color@8.1.1)
       mdast:
         specifier: ^3.0.0
         version: 3.0.0
@@ -135,6 +138,12 @@ importers:
         specifier: 3.20.1
         version: 3.20.1
     devDependencies:
+      '@types/debug':
+        specifier: ^4.1.7
+        version: 4.1.7
+      '@types/mdast':
+        specifier: ^3.0.11
+        version: 3.0.11
       '@types/unist':
         specifier: ^2.0.3
         version: 2.0.6
@@ -810,8 +819,8 @@ packages:
   /@types/katex@0.16.0:
     resolution: {integrity: sha512-hz+S3nV6Mym5xPbT9fnO8dDhBFQguMYpY0Ipxv06JMi1ORgnEM4M1ymWDUhUNer3ElLmT583opRo4RzxKmh9jw==}
 
-  /@types/mdast@3.0.10:
-    resolution: {integrity: sha512-W864tg/Osz1+9f4lrGTZpCSO5/z4608eUp19tbozkq2HJK6i3z1kT0H9tlADXuYIb1YYOBByU4Jsqkk75q48qA==}
+  /@types/mdast@3.0.11:
+    resolution: {integrity: sha512-Y/uImid8aAwrEA24/1tcRZwpxX3pIFTSilcNDKSPn+Y2iDywSEachzRuvgAYYLR3wpGXAsMbv5lvKLDZLeYPAw==}
     dependencies:
       '@types/unist': 2.0.6
 
@@ -2864,7 +2873,7 @@ packages:
   /mdast-util-definitions@5.1.1:
     resolution: {integrity: sha512-rQ+Gv7mHttxHOBx2dkF4HWTg+EE+UR78ptQWDylzPKaQuVGdG4HIoY3SrS/pCp80nZ04greFvXbVFHT+uf0JVQ==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       '@types/unist': 2.0.6
       unist-util-visit: 4.1.2
     dev: false
@@ -2872,7 +2881,7 @@ packages:
   /mdast-util-from-markdown@1.3.0:
     resolution: {integrity: sha512-HN3W1gRIuN/ZW295c7zi7g9lVBllMgZE40RxCX37wrTPWXCWtpvOZdfnuK+1WNpvZje6XuJeI3Wnb4TJEUem+g==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       '@types/unist': 2.0.6
       decode-named-character-reference: 1.0.2
       mdast-util-to-string: 3.1.0
@@ -2890,7 +2899,7 @@ packages:
   /mdast-util-math@2.0.2:
     resolution: {integrity: sha512-8gmkKVp9v6+Tgjtq6SYx9kGPpTf6FVYRa53/DLh479aldR9AyP48qeVOgNZ5X7QUK7nOy4yw7vg6mbiGcs9jWQ==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       longest-streak: 3.1.0
       mdast-util-to-markdown: 1.3.0
     dev: false
@@ -2899,7 +2908,7 @@ packages:
     resolution: {integrity: sha512-a21xoxSef1l8VhHxS1Dnyioz6grrJkoaCUgGzMD/7dWHvboYX3VW53esRUfB5tgTyz4Yos1n25SPcj35dJqmAg==}
     dependencies:
       '@types/hast': 2.3.4
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       mdast-util-definitions: 5.1.1
       micromark-util-sanitize-uri: 1.1.0
       trim-lines: 3.0.1
@@ -2912,7 +2921,7 @@ packages:
   /mdast-util-to-markdown@1.3.0:
     resolution: {integrity: sha512-6tUSs4r+KK4JGTTiQ7FfHmVOaDrLQJPmpjD6wPMlHGUVXoG9Vjc3jIeP+uyBWRf8clwB2blM+W7+KrlMYQnftA==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       '@types/unist': 2.0.6
       longest-streak: 3.1.0
       mdast-util-to-string: 3.1.0
@@ -3569,7 +3578,7 @@ packages:
   /remark-math@5.1.1:
     resolution: {integrity: sha512-cE5T2R/xLVtfFI4cCePtiRn+e6jKMtFDR3P8V3qpv8wpKjwvHoBA4eJzvX+nVrnlNy0911bdGmuspCSwetfYHw==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       mdast-util-math: 2.0.2
       micromark-extension-math: 2.1.0
       unified: 10.1.2
@@ -3578,7 +3587,7 @@ packages:
   /remark-parse@10.0.1:
     resolution: {integrity: sha512-1fUyHr2jLsVOkhbvPRBJ5zTKZZyD6yZzYaWCS6BPBdQ8vEMBCH+9zNCDA6tET/zHCi/jLqjCWtlJZUPk+DbnFw==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       mdast-util-from-markdown: 1.3.0
       unified: 10.1.2
     transitivePeerDependencies:
@@ -3589,7 +3598,7 @@ packages:
     resolution: {integrity: sha512-EFmR5zppdBp0WQeDVZ/b66CWJipB2q2VLNFMabzDSGR66Z2fQii83G5gTBbgGEnEEA0QRussvrFHxk1HWGJskw==}
     dependencies:
       '@types/hast': 2.3.4
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       mdast-util-to-hast: 12.2.4
       unified: 10.1.2
     dev: false
@@ -3597,7 +3606,7 @@ packages:
   /remark-stringify@10.0.2:
     resolution: {integrity: sha512-6wV3pvbPvHkbNnWB0wdDvVFHOe1hBRAx1Q/5g/EpH4RppAII6J8Gnwe7VbHuXaoKIF6LAg6ExTel/+kNqSQ7lw==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       mdast-util-to-markdown: 1.3.0
       unified: 10.1.2
     dev: false
@@ -3605,7 +3614,7 @@ packages:
   /remark@14.0.2:
     resolution: {integrity: sha512-A3ARm2V4BgiRXaUo5K0dRvJ1lbogrbXnhkJRmD0yw092/Yl0kOCZt1k9ZeElEwkZsWGsMumz6qL5MfNJH9nOBA==}
     dependencies:
-      '@types/mdast': 3.0.10
+      '@types/mdast': 3.0.11
       remark-parse: 10.0.1
       remark-stringify: 10.0.2
       unified: 10.1.2


### PR DESCRIPTION
Pushes more parser configuration down to the core layer, adding some debugging and fixing some apparent event handling errors

The live editor preview now fully renders the example text without error (though we still need to do some work to get the internal / external links to display as intended).