### PR TITLE
fix: loading bar

### DIFF
--- a/packages/viewer/src/stores/deduction.ts
+++ b/packages/viewer/src/stores/deduction.ts
@@ -83,7 +83,9 @@ export function create(
 
   theorems.subscribe($theorems => {
     implications = indexTheorems($theorems)
-    run()
+
+    // Ensure that the trait store is updated before deductions run
+    setTimeout(run, 0)
   })
 
   function run() {
@@ -96,19 +98,7 @@ export function create(
 
     const checked = read(store).checked
 
-    // HACK: there's a subtle timing issue where the first space is checked
-    // before the store's traits have been updated, causing deduction to fail
-    // to derive any traits. Adding a non-existent space is a hacky way of
-    // deferring the first real space's check until the store is ready.
-    const unchecked: Space[] = [
-      {
-        id: 0,
-        name: 'FIXME',
-        description: 'FIXME',
-        aliases: [],
-        refs: [],
-      },
-    ]
+    const unchecked: Space[] = []
     allSpaces.forEach(s => {
       if (!checked.has(s.id)) {
         unchecked.push(s)


### PR DESCRIPTION
The previous fix for S000001 failing to find deductions caused an off-by-one error that prevent the loading bar from ever completing. This should be a better fix to both.

Fixes #46