### PR TITLE
feat: support searching where value is unknown

### DIFF
--- a/packages/core/src/Formula/Grammar.pegjs
+++ b/packages/core/src/Formula/Grammar.pegjs
@@ -13,7 +13,7 @@ Or = _ "(" _ head:Formula tail:(_ Disjunction _ Formula)+ _ ")" _ {
 Atom = mod:Modifier? _ prop:Property {
   let value;
   if (mod === '?') {
-    value = undefined
+    value = null
   } else if (mod) {
     value = false
   } else {

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -17,13 +17,9 @@ export default defineConfig({
   },
   test: {
     coverage: {
-      lines: 92.52,
-      branches: 95.32,
-      statements: 92.52,
-      functions: 83.33,
       skipFull: true,
       thresholdAutoUpdate: true,
-      exclude: ['src/Formula/Grammar.ts'],
+      exclude: ['src/Formula/Grammar.ts', 'test'],
     },
   },
 })

--- a/packages/core/vite.config.ts
+++ b/packages/core/vite.config.ts
@@ -17,6 +17,10 @@ export default defineConfig({
   },
   test: {
     coverage: {
+      lines: 91.27,
+      branches: 94.01,
+      statements: 91.27,
+      functions: 83.55,
       skipFull: true,
       thresholdAutoUpdate: true,
       exclude: ['src/Formula/Grammar.ts', 'test'],

--- a/packages/viewer/src/components/Shared/Formula.svelte
+++ b/packages/viewer/src/components/Shared/Formula.svelte
@@ -4,7 +4,7 @@
   import Atom from './Formula/Atom.svelte'
   import Compound from './Formula/Compound.svelte'
 
-  export let value: Formula<Property>
+  export let value: Formula<Property, null>
   export let link = true
 </script>
 

--- a/packages/viewer/src/components/Shared/Formula/Atom.svelte
+++ b/packages/viewer/src/components/Shared/Formula/Atom.svelte
@@ -4,11 +4,11 @@
   import { Link, Typeset } from '@/components/Shared'
   import type { Property } from '@/models'
 
-  export let value: Atom<Property>
+  export let value: Atom<Property, null>
   export let link: boolean = true
 </script>
 
-{value.value ? '' : '¬'}
+{value.value === null ? '?' : value.value ? '' : '¬'}
 {#if link}
   <Link.Property property={value.property} />
 {:else}

--- a/packages/viewer/src/components/Shared/Formula/Compound.svelte
+++ b/packages/viewer/src/components/Shared/Formula/Compound.svelte
@@ -5,7 +5,7 @@
 
   import Formula from '../Formula.svelte'
 
-  export let value: And<Property> | Or<Property>
+  export let value: And<Property, null> | Or<Property, null>
   export let link = true
 
   $: connector = value.kind === 'and' ? '∧' : '∨'

--- a/packages/viewer/src/components/Shared/Formula/Input/store.ts
+++ b/packages/viewer/src/components/Shared/Formula/Input/store.ts
@@ -25,7 +25,7 @@ export function create({
   limit = 10,
 }: {
   raw: Writable<string>
-  formula: Writable<Formula<Property> | undefined>
+  formula: Writable<Formula<Property, null> | undefined>
   properties: Readable<Collection<Property>>
   limit?: number
 }): Store {
@@ -103,7 +103,7 @@ export function create({
 function resolve(
   index: Fuse<Property>,
   str: string,
-): Formula<Property> | undefined {
+): Formula<Property, null> | undefined {
   const parsed = F.parse(str)
   if (!parsed) {
     return


### PR DESCRIPTION
Adds minimal support for 3-valued logic. Formula types support arbitrarily many extended types with the default (X = never) type, but parsing and evaluating is currently only well-defined for value types that extend (boolean | null).

Note that we're using null to represent unknown here in part so that helpers like

    atom(property, value = true)

can distinguish between being called with an unknown and being called without providing the default argument.

Fixes #70

---

# 🔬 Testing Notes

Visiting [this search url](https://3-valued-logic.topology.pages.dev/spaces?q=t2+%2B+%3FParacompact) shows

<img width="692" alt="Screenshot 2023-11-06 at 9 09 29 AM" src="https://github.com/pi-base/web/assets/1079270/99aab830-cdee-48df-bdf6-5ad2fde637da">
