### PR TITLE
feat: support {S#|P#} syntax for linking to traits

### DIFF
--- a/packages/viewer/cypress/e2e/typesetting.spec.ts
+++ b/packages/viewer/cypress/e2e/typesetting.spec.ts
@@ -1,0 +1,17 @@
+import { deduce, setup } from '../support'
+
+beforeEach(setup)
+
+it('renders internal links', () => {
+  cy.visit('dev/preview')
+  deduce()
+
+  cy.get('[data-testid=input]').type(
+    // {{} is Cypress escaping for {. See https://docs.cypress.io/api/commands/type#Arguments
+    `{{}S000001} is {{}P000001} as noted in {{}S000001|P000001}`,
+  )
+
+  cy.get('[data-testid=output]').contains(
+    'Discrete topology on a two-point set is $T_0$ as noted in Discrete topology on a two-point set | $T_0$',
+  )
+})

--- a/packages/viewer/src/components/Dev/Example.svelte
+++ b/packages/viewer/src/components/Dev/Example.svelte
@@ -8,6 +8,7 @@ This is a list of links
 * {S000123}
 * {P000123}
 * {T000123}
+* {S000123|P000123}
 * {{doi:123}}
 * {{mr:123}}
 * {{wikipedia:123}}
@@ -37,6 +38,9 @@ This is a list of links
         - e.g.
         <code>{'{S000001}'}</code>
         for space 1
+        <br />
+        <code>{'{S000001|P000002}'}</code>
+        for space 1's value of property 2
       </td>
     </tr>
     <tr>

--- a/packages/viewer/src/components/Dev/Preview.svelte
+++ b/packages/viewer/src/components/Dev/Preview.svelte
@@ -11,7 +11,12 @@
 <div class="row">
   <div class="col-sm">
     <div class="input-group">
-      <textarea bind:value={body} class="form-control" {rows} />
+      <textarea
+        bind:value={body}
+        class="form-control"
+        data-testid="input"
+        {rows}
+      />
     </div>
     <div class="input-group">
       <div class="form-check">
@@ -31,7 +36,7 @@
       }}
     />
   </div>
-  <div class="col-sm">
+  <div class="col-sm" data-testid="output">
     <Typeset {body} {truncated} />
   </div>
 </div>

--- a/packages/viewer/src/components/Shared/Typeset.svelte
+++ b/packages/viewer/src/components/Shared/Typeset.svelte
@@ -15,7 +15,18 @@
       return
     }
 
-    container.innerHTML = await $typeset(text, truncated_)
+    try {
+      container.innerHTML = await $typeset(text, truncated_)
+    } catch (e: any) {
+      // FIXME: this is a kludgey fix for the fact that the {id} parser throws
+      // assertion errors on incomplete / unbalanced sets of {}s. The better fix
+      // is to make it more robust.
+      if (e?.name === 'Assertion') {
+        console.warn(e)
+      } else {
+        throw e
+      }
+    }
 
     /**
      * We're adding "real" <a/> tags to the DOM, even for parsed internal

--- a/packages/viewer/src/parser/internalLinks.test.ts
+++ b/packages/viewer/src/parser/internalLinks.test.ts
@@ -55,4 +55,13 @@ describe('with ambient data', () => {
       expect(link(['S', '000003'])).toEqual('Could not find Space S000003')
     })
   })
+
+  describe('traits', () => {
+    it('can link to traits', () => {
+      expect(link(['S', '000001|P000002'])).toEqual({
+        href: '/spaces/S000001/properties/P000002',
+        title: 'S000001 | Two',
+      })
+    })
+  })
 })

--- a/packages/viewer/src/parser/internalLinks.ts
+++ b/packages/viewer/src/parser/internalLinks.ts
@@ -9,6 +9,20 @@ export function internal(
   return function linker([kind, id]: ['S' | 'P' | 'T', string]) {
     switch (kind) {
       case 'S':
+        // Support e.g. {S001|P002} as a link to the trait
+        const match = /(?<sid>\d+)\|P(?<pid>\d+)/.exec(id)
+        if (match?.groups) {
+          const { sid, pid } = match.groups
+          const space = spaces.find(Number(sid))
+          const property = properties.find(Number(pid))
+          return {
+            href: `/spaces/S${sid}/properties/P${pid}`,
+            title: `${space ? space.name : 'S' + sid} | ${
+              property ? property.name : 'P' + pid
+            }`,
+          }
+        }
+
         const space = spaces.find(Number(id))
         return {
           href: `/spaces/S${id}`,

--- a/packages/viewer/vite.config.js
+++ b/packages/viewer/vite.config.js
@@ -7,9 +7,9 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     coverage: {
-      lines: 80.01,
-      branches: 87.97,
-      statements: 80.01,
+      lines: 80.25,
+      branches: 87.16,
+      statements: 80.25,
       functions: 81,
       skipFull: true,
       thresholdAutoUpdate: true,


### PR DESCRIPTION
fixes #66

Should support `{S1|P1}`, with arbitrary many `0`s for padding. Try it out on the `/dev/preview` page.