### PR TITLE
feat: proxying to local bundle server in dev

### DIFF
--- a/packages/viewer/vite.config.js
+++ b/packages/viewer/vite.config.js
@@ -1,9 +1,19 @@
 import { sveltekit } from '@sveltejs/kit/vite'
 import { defineConfig } from 'vitest/config'
 
+const compileServer = process.env.COMPILE_SERVER_URL || 'http://localhost:3141'
+
 // https://vitejs.dev/config/
 export default defineConfig({
   plugins: [sveltekit()],
+  server: {
+    proxy: {
+      '/bundle': {
+        target: compileServer,
+        rewrite: path => path.replace(/^\/bundle/, ''),
+      },
+    },
+  },
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     coverage: {


### PR DESCRIPTION
With this, setting

```
VITE_BUNDLE_HOST=/bundle # or <explicit viewer host>/bundle
VITE_BUNDLE_SSE=true
```

should proxy bundle requests to a locally running `compile` server (at `COMPILE_SERVER_URL:=http://localhost:3141`) and reload the viewer on bundle rebuilds.