### PR TITLE
Switch from T57 to T21

### DIFF
--- a/packages/viewer/src/components/Home.svelte
+++ b/packages/viewer/src/components/Home.svelte
@@ -24,8 +24,8 @@
       </p>
       <p class="mb-0">
         ➜ Find counterexamples:
-        <a href="/theorems/T000057" class="text-info"
-          >first countable spaces need not be locally pseudometrizable</a
+        <a href="/theorems/T000021" class="text-info"
+          >spaces with the countable chain condition need not be separable</a
         >
       </p>
     </div>

--- a/packages/viewer/src/components/Home.svelte
+++ b/packages/viewer/src/components/Home.svelte
@@ -24,8 +24,8 @@
       </p>
       <p class="mb-0">
         ➜ Find counterexamples:
-        <a href="/theorems/T000021" class="text-info"
-          >spaces with the countable chain condition need not be separable</a
+        <a href="/theorems/T000040" class="text-info"
+          >connected spaces need not be path connected</a
         >
       </p>
     </div>


### PR DESCRIPTION
This will change the example theorem on the home page from T57 (involving locally pseudometrizable!) to T21 (involving CCC + separable)