### PR TITLE
Trim descriptions of traits

### DIFF
--- a/packages/compile/src/validations.ts
+++ b/packages/compile/src/validations.ts
@@ -246,7 +246,7 @@ export function trait(input: File) {
       value: Boolean(value),
       counterexamples_id,
       refs,
-      description,
+      description: String(description).trim(),
     })
 
     if (!input.path.endsWith(paths.trait({ space, property }))) {


### PR DESCRIPTION
The descriptions in other types of files have the whitespace trimmed from their ends; this makes the same done for trait files. This should reduce the size of the data JSON file by ~5kB.