### PR TITLE
fix matching issue

### DIFF
--- a/packages/viewer/src/components/Shared/Formula/Input/store.ts
+++ b/packages/viewer/src/components/Shared/Formula/Input/store.ts
@@ -6,7 +6,7 @@ import { formula as F } from '@pi-base/core'
 import type { Collection, Formula, Property } from '@/models'
 import { read } from '@/util'
 
-import { searchThreshold } from '@/constants'
+import { searchThreshold, searchKeys } from '@/constants'
 
 export type State = {
   suggest: boolean
@@ -32,11 +32,7 @@ export function create({
   limit?: number
 }): Store {
   const index = new Fuse<Property>([], {
-    keys: [
-      { name: 'name', weight: 1 },
-      { name: 'aliases', weight: 0.7 },
-      { name: 'description', weight: 0.3 },
-    ],
+    keys: searchKeys,
     threshold: searchThreshold,
   })
 

--- a/packages/viewer/src/components/Shared/Formula/Input/store.ts
+++ b/packages/viewer/src/components/Shared/Formula/Input/store.ts
@@ -6,6 +6,8 @@ import { formula as F } from '@pi-base/core'
 import type { Collection, Formula, Property } from '@/models'
 import { read } from '@/util'
 
+import { searchThreshold } from '@/constants'
+
 export type State = {
   suggest: boolean
   suggestions: Property[]
@@ -32,8 +34,10 @@ export function create({
   const index = new Fuse<Property>([], {
     keys: [
       { name: 'name', weight: 1 },
-      { name: 'aliases', weight: 1 },
+      { name: 'aliases', weight: 0.7 },
+      { name: 'description', weight: 0.3 },
     ],
+    threshold: searchThreshold,
   })
 
   const initial = { suggest: false, suggestions: [], selected: undefined }

--- a/packages/viewer/src/constants.ts
+++ b/packages/viewer/src/constants.ts
@@ -23,4 +23,15 @@ export const helpUrl = `https://github.com/pi-base/data/wiki/`
 export const sentryIngest =
   'https://0fa430dd1dc347e2a82c413d8e3acb75@o397472.ingest.sentry.io/5251960'
 
+// Used for Fuse searches
+export const searchWeights = {
+  name: 1,
+  aliases: 0.7,
+  description: 0.3,
+}
+export const searchKeys = [
+  { name: 'name', weight: 1 },
+  { name: 'aliases', weight: 0.7 },
+  { name: 'description', weight: 0.3 },
+]
 export const searchThreshold = 0.3

--- a/packages/viewer/src/routes/(app)/properties/+page.ts
+++ b/packages/viewer/src/routes/(app)/properties/+page.ts
@@ -3,6 +3,8 @@ import { derived } from 'svelte/store'
 import { list } from '@/stores'
 import type { PageLoad } from './$types'
 
+import { searchWeights } from '@/constants'
+
 export const load: PageLoad = async function ({ parent, url }) {
   const { properties } = await parent()
 
@@ -10,7 +12,7 @@ export const load: PageLoad = async function ({ parent, url }) {
     properties: list(
       derived(properties, ps => ps.all),
       {
-        weights: { name: 0.7, aliases: 0.7, description: 0.3 },
+        weights: searchWeights,
       },
     ),
   }

--- a/packages/viewer/src/routes/(app)/spaces/all/+page.ts
+++ b/packages/viewer/src/routes/(app)/spaces/all/+page.ts
@@ -3,6 +3,8 @@ import { derived } from 'svelte/store'
 import { list } from '@/stores'
 import type { PageLoad } from './$types'
 
+import { searchWeights } from '@/constants'
+
 export const load: PageLoad = async function ({ parent, url }) {
   const { spaces } = await parent()
 
@@ -10,7 +12,7 @@ export const load: PageLoad = async function ({ parent, url }) {
     spaces: list(
       derived(spaces, ss => ss.all),
       {
-        weights: { name: 0.7, aliases: 0.7, description: 0.3 },
+        weights: searchWeights,
       },
     ),
   }

--- a/packages/viewer/src/routes/(app)/theorems/+page.ts
+++ b/packages/viewer/src/routes/(app)/theorems/+page.ts
@@ -3,6 +3,8 @@ import { derived } from 'svelte/store'
 import { list } from '@/stores'
 import type { PageLoad } from './$types'
 
+import { searchWeights } from '@/constants'
+
 export const load: PageLoad = async function ({ parent, url }) {
   const { theorems } = await parent()
 
@@ -10,7 +12,7 @@ export const load: PageLoad = async function ({ parent, url }) {
     theorems: list(
       derived(theorems, ts => ts.all),
       {
-        weights: { name: 0.7, description: 0.3 },
+        weights: searchWeights,
       },
     ),
   }

--- a/packages/viewer/src/stores/search.ts
+++ b/packages/viewer/src/stores/search.ts
@@ -1,7 +1,7 @@
 import Fuse from 'fuse.js'
 import { type Readable, derived, writable } from 'svelte/store'
 
-import { searchThreshold } from '@/constants'
+import { searchThreshold, searchKeys } from '@/constants'
 
 import type { Collection, Formula, Property, Space, Traits } from '@/models'
 import { read } from '@/util'
@@ -28,11 +28,7 @@ export default function create({
     spaces,
     $spaces =>
       new Fuse($spaces.all, {
-        keys: [
-          { name: 'name', weight: 1 },
-          { name: 'aliases', weight: 0.7 },
-          { name: 'description', weight: 0.3 },
-        ],
+        keys: searchKeys,
         threshold: searchThreshold,
       }),
   )

--- a/packages/viewer/src/stores/search.ts
+++ b/packages/viewer/src/stores/search.ts
@@ -29,7 +29,7 @@ export default function create({
     $spaces =>
       new Fuse($spaces.all, {
         keys: [
-          { name: 'name', weight: 0.7 },
+          { name: 'name', weight: 1 },
           { name: 'aliases', weight: 0.7 },
           { name: 'description', weight: 0.3 },
         ],


### PR DESCRIPTION
See discussion at https://github.com/pi-base/data/pull/959

Fixes issue where `/spaces?q=Semi-Hausdorff` matches `US` instead of `Semi-Hausdorff`.