### PR TITLE
fix(viewer): Unneeded manual internal link; Fix target is in LaTeX

### DIFF
--- a/packages/viewer/src/components/Shared/Typeset.svelte
+++ b/packages/viewer/src/components/Shared/Typeset.svelte
@@ -28,11 +28,6 @@
       }
     }
 
-    /**
-     * We're adding "real" <a/> tags to the DOM, even for parsed internal
-     * links, but we really want to use the router to navigate. So we manually
-     * bind click handlers to trigger navigation.
-     */
     for (const link of container.getElementsByClassName('internal-link')) {
       /**
        * Unloading a DOM node should remove any bound listeners, but it's
@@ -48,10 +43,6 @@
       })
 
       link.setAttribute('_wired', 'true')
-      link.addEventListener('click', e => {
-        e.preventDefault()
-        goto((e.target as HTMLAnchorElement).href)
-      })
     }
   }
 


### PR DESCRIPTION
Svelte has automatically internal link mechanism, so the manual implementation is not necessary and it is also wrong: When user click internal link just in LaTeX, it will goto undefined. So we simply delete it and it works well.

https://github.com/pi-base/web/blob/c571c9301b32c7f17fb074307b9500ade99d87c9/packages/viewer/src/components/Shared/Typeset.svelte#L51-L54

`e.target` is not necessary an `<a>`, it may deep inside a KaTeX node.