### PR TITLE
fetch bundles from R2

### DIFF
--- a/packages/viewer/src/constants.ts
+++ b/packages/viewer/src/constants.ts
@@ -1,7 +1,5 @@
-import { bundle } from '@pi-base/core'
-
 const {
-  VITE_BUNDLE_HOST = bundle.defaultHost,
+  VITE_BUNDLE_HOST = 'https://pub-65041ca69d744da88ade13abd31ad834.r2.dev', // TODO: push down to @pi-base/core?
   VITE_BUNDLE_SSE = 'false',
   VITE_BRANCH = 'unknown',
   VITE_MAIN_BRANCH = 'main',


### PR DESCRIPTION
Related to pi-base/data#1288 – the S3 egress costs are getting non-trivial, so I'd like to get things cut over to R2 as a stopgap, and then more thoughfully rework the "generate a JSON blob of the whole universe on every build" data model.

I did a one-time true up of the two buckets locally with

```bash
aws s3 sync s3://pi-base-bundles /tmp/bundles
aws --profile pi-base-r2 sync /tmp/bundles s3://pi-base 
```

to attempt to cover historical branches that were missed when R2 pushes were off and can re-run again to catch anything new from now until when pi-base/data#1288 merges

# Testing Notes

At https://jcd-source-from-r2.topology.pages.dev

  * [x] `/dev` points to R2
  * [x] Loads without error
  * [x] Swapping branches to `subpara` (a ~new branch not pushed to R2 by CI) also loads without error 

Using #219 

* [x] `BRANCH=jcd/source-from-r2 pnpm run cy:open:prev` fully passes tests