### PR TITLE
ci: add tests covering top-level context setup

### DIFF
--- a/packages/viewer/.vscode/keybindings.json
+++ b/packages/viewer/.vscode/keybindings.json
@@ -1,0 +1,27 @@
+[
+  {
+    "key": "cmd+shift+t",
+    "command": "workbench.action.tasks.runTask",
+    "args": "Run Tests"
+  },
+  {
+    "key": "cmd+shift+w",
+    "command": "workbench.action.tasks.runTask", 
+    "args": "Watch Tests"
+  },
+  {
+    "key": "cmd+shift+c",
+    "command": "workbench.action.tasks.runTask",
+    "args": "Test with Coverage"
+  },
+  {
+    "key": "cmd+shift+v",
+    "command": "workbench.action.tasks.runTask",
+    "args": "View Coverage Report"
+  },
+  {
+    "key": "cmd+shift+y",
+    "command": "workbench.action.tasks.runTask",
+    "args": "Open Cypress"
+  }
+]

--- a/packages/viewer/.vscode/launch.json
+++ b/packages/viewer/.vscode/launch.json
@@ -1,0 +1,44 @@
+{
+  "version": "0.2.0",
+  "configurations": [
+    {
+      "name": "Debug Current Test File",
+      "type": "node",
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run", "${relativeFile}"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
+    {
+      "name": "Debug All Tests",
+      "type": "node", 
+      "request": "launch",
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["run"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    },
+    {
+      "name": "Debug Tests in Watch Mode",
+      "type": "node",
+      "request": "launch", 
+      "program": "${workspaceFolder}/node_modules/vitest/vitest.mjs",
+      "args": ["--watch"],
+      "console": "integratedTerminal",
+      "internalConsoleOptions": "neverOpen",
+      "cwd": "${workspaceFolder}",
+      "env": {
+        "NODE_ENV": "test"
+      }
+    }
+  ]
+}

--- a/packages/viewer/.vscode/settings.json
+++ b/packages/viewer/.vscode/settings.json
@@ -1,0 +1,12 @@
+{
+  "vitest.enable": true,
+  "vitest.workspaceConfig": "./vite.config.js",
+  "vitest.commandLine": "npm run test:watch",
+  "testing.automaticallyOpenPeekView": "failureInVisibleDocument",
+  "testing.defaultGutterClickAction": "run",
+  "testing.followRunningTest": "true",
+  "testing.openTesting": "neverOpen",
+  "files.watcherExclude": {
+    "**/coverage/**": true
+  }
+}

--- a/packages/viewer/.vscode/settings.json
+++ b/packages/viewer/.vscode/settings.json
@@ -8,5 +8,6 @@
   "testing.openTesting": "neverOpen",
   "files.watcherExclude": {
     "**/coverage/**": true
-  }
+  },
+  "testing.automaticallyOpenTestResults": "neverOpen"
 }

--- a/packages/viewer/.vscode/tasks.json
+++ b/packages/viewer/.vscode/tasks.json
@@ -1,0 +1,113 @@
+{
+  "version": "2.0.0",
+  "tasks": [
+    {
+      "label": "Run Tests",
+      "type": "shell",
+      "command": "npm run test",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Watch Tests",
+      "type": "shell", 
+      "command": "npm run test:watch",
+      "group": "test",
+      "isBackground": true,
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Test with Coverage",
+      "type": "shell",
+      "command": "npm run test:cov",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always", 
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "View Coverage Report",
+      "type": "shell",
+      "command": "open",
+      "args": ["coverage/index.html"],
+      "group": "test",
+      "dependsOn": "Test with Coverage",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Open Cypress",
+      "type": "shell",
+      "command": "npm run cy:open", 
+      "group": "test",
+      "isBackground": true,
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "dedicated",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Run Single Test File",
+      "type": "shell",
+      "command": "npx vitest run ${relativeFile}",
+      "group": "test",
+      "presentation": {
+        "echo": true,
+        "reveal": "always",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": true,
+        "clear": false
+      },
+      "problemMatcher": []
+    },
+    {
+      "label": "Clean Coverage",
+      "type": "shell",
+      "command": "rm -rf coverage",
+      "group": "build",
+      "presentation": {
+        "echo": true,
+        "reveal": "silent",
+        "focus": false,
+        "panel": "shared",
+        "showReuseMessage": false,
+        "clear": false
+      }
+    }
+  ]
+}

--- a/packages/viewer/src/context.test.ts
+++ b/packages/viewer/src/context.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it, vi, type MockedFunction } from 'vitest'
+import { initialize } from './context'
+import { writable, type Writable } from 'svelte/store'
+import * as Errors from './errors'
+import type * as Gateway from './gateway'
+import type { Local } from './repositories'
+import { renderer } from './parser'
+import { type Prestore } from './stores'
+import { property, space } from './__test__/factories'
+import { get } from 'svelte/store'
+import type { Result } from './gateway'
+
+type InitializeParams = Parameters<typeof initialize>[0]
+
+type SetupParams = {
+  local: Partial<Prestore>
+  remote: Result
+} & Pick<InitializeParams, 'showDev' | 'source'>
+
+describe(initialize, () => {
+  let db: Local<Prestore> & {
+    subscribe: MockedFunction<Local<Prestore>['subscribe']>
+  }
+  let errorHandler: MockedFunction<Errors.Handler>
+  let gateway: MockedFunction<Gateway.Sync>
+  let mockRenderer: typeof renderer
+
+  function setup(args: Partial<SetupParams> = {}) {
+    vi.clearAllMocks()
+
+    errorHandler = vi.fn()
+    mockRenderer = vi.fn()
+
+    const prestore: Prestore = {
+      spaces: [],
+      properties: [],
+      theorems: [],
+      traits: [],
+      deduction: { checked: new Set(), all: new Set() },
+      source: { host: 'example.com', branch: 'main' },
+      sync: undefined,
+      ...args.local,
+    }
+
+    db = {
+      load: () => prestore,
+      subscribe: vi.fn(),
+    }
+
+    gateway = vi.fn(async (_host: string, _branch: string) => args.remote)
+
+    return initialize({
+      db,
+      errorHandler,
+      gateway,
+      typesetter: mockRenderer,
+      showDev: args.showDev || false,
+      source: args.source || {},
+    })
+  }
+
+  it('should create a context with default dependencies', () => {
+    const { showDev, errorHandler } = setup()
+
+    expect(showDev).toBe(false)
+    expect(errorHandler).toEqual(errorHandler)
+  })
+
+  it('use the provided source', () => {
+    const { source } = setup({
+      source: { host: 'default.com', branch: 'master' },
+    })
+
+    expect(get(source)).toEqual({ host: 'default.com', branch: 'master' })
+  })
+
+  it('should trigger sync when local sync state is undefined', () => {
+    setup({
+      local: {
+        source: { host: 'example.com', branch: 'main' },
+        sync: undefined,
+      },
+    })
+
+    expect(gateway).toHaveBeenCalledWith('example.com', 'main', undefined)
+  })
+
+  it('persists remote sync state to the local db', async () => {
+    const context = setup({
+      local: {
+        source: { host: 'example.com', branch: 'main' },
+        sync: undefined,
+      },
+      remote: {
+        spaces: [space({ id: 123 })],
+        properties: [property({ id: 456 })],
+        theorems: [],
+        traits: [],
+        etag: 'etag',
+        sha: 'sha',
+      },
+    })
+
+    await context.loaded()
+
+    const { spaces, properties, sync } = db.subscribe.mock.calls[0][0]
+
+    expect(get(spaces).map(s => s.id)).toEqual([123])
+    expect(get(properties).map(p => p.id)).toEqual([456])
+    expect(get(sync)).toEqual(
+      expect.objectContaining({
+        kind: 'fetched',
+        value: { etag: 'etag', sha: 'sha' },
+      }),
+    )
+  })
+
+  it('runs deductions', async () => {
+    const context = setup({
+      local: {
+        spaces: [space({ id: 1 })],
+        properties: [property({ id: 1 }), property({ id: 2 })],
+        traits: [
+          {
+            asserted: true,
+            space: 1,
+            property: 1,
+            value: true,
+            description: '',
+            refs: [],
+          },
+        ],
+        theorems: [
+          {
+            id: 1,
+            when: { kind: 'atom', property: 1, value: true },
+            then: { kind: 'atom', property: 2, value: true },
+            description: '',
+            refs: [],
+          },
+        ],
+      },
+    })
+
+    await context.checked('S1')
+
+    const { trait, proof } = get(context.traits).lookup({
+      spaceId: 'S1',
+      propertyId: 'P2',
+      theorems: get(context.theorems),
+    })!
+
+    expect(trait?.value).toEqual(true)
+    expect(proof?.theorems.map(t => t.id)).toEqual([1])
+  })
+
+  it('can wait for a space to be checked', async () => {
+    const { checked } = setup({
+      local: {
+        spaces: [space({ id: 123 })],
+      },
+    })
+
+    expect(checked('S123')).resolves.toBeUndefined()
+  })
+
+  describe('load', () => {
+    let store: Writable<number>
+
+    it('resolves when lookup finds value', async () => {
+      store = writable(0)
+      const context = setup()
+
+      const loadPromise = context.load(store, n => (n > 10 ? n : false))
+
+      store.set(5)
+      store.set(13)
+
+      await expect(loadPromise).resolves.toBe(13)
+    })
+
+    it('rejects when until promise resolves first', async () => {
+      store = writable(0)
+      const context = setup()
+
+      const loadPromise = context.load(store, n => n > 0, Promise.resolve())
+
+      await expect(loadPromise).rejects.toBeUndefined()
+    })
+  })
+})

--- a/packages/viewer/src/context.test.ts
+++ b/packages/viewer/src/context.test.ts
@@ -6,7 +6,7 @@ import type * as Gateway from './gateway'
 import type { Local } from './repositories'
 import { renderer } from './parser'
 import { type Prestore } from './stores'
-import { property, space } from './__test__/factories'
+import { property, space, theorem } from './__test__/factories'
 import { get } from 'svelte/store'
 import type { Result } from './gateway'
 
@@ -131,13 +131,11 @@ describe(initialize, () => {
           },
         ],
         theorems: [
-          {
+          theorem({
             id: 1,
             when: { kind: 'atom', property: 1, value: true },
             then: { kind: 'atom', property: 2, value: true },
-            description: '',
-            refs: [],
-          },
+          }),
         ],
       },
     })

--- a/packages/viewer/src/context.ts
+++ b/packages/viewer/src/context.ts
@@ -2,7 +2,7 @@ export type { Context } from './context/types'
 
 import { formula as F } from '@pi-base/core'
 import { getContext, setContext } from 'svelte'
-import { derived, get, type Readable } from 'svelte/store'
+import { derived, type Readable } from 'svelte/store'
 
 import type { Context } from '@/context/types'
 import { trace } from '@/debug'

--- a/packages/viewer/src/models/Traits.ts
+++ b/packages/viewer/src/models/Traits.ts
@@ -74,14 +74,14 @@ export default class Traits {
   lookup({
     spaceId,
     propertyId,
-    spaces,
-    properties,
+    spaces = this.spaces,
+    properties = this.properties,
     theorems,
   }: {
     spaceId: string
     propertyId: string
-    spaces: Collection<Space>
-    properties: Collection<Property>
+    spaces?: Collection<Space>
+    properties?: Collection<Property>
     theorems: Theorems
   }) {
     const space = spaces.find(spaceId)

--- a/packages/viewer/src/stores/deduction.test.ts
+++ b/packages/viewer/src/stores/deduction.test.ts
@@ -1,0 +1,300 @@
+import { describe, expect, it } from 'vitest'
+import { writable, get } from 'svelte/store'
+import {
+  Collection,
+  Theorem,
+  Theorems,
+  Traits,
+  type Property,
+  type Space,
+  type Trait,
+} from '@/models'
+import * as Deduction from './deduction'
+import {
+  and,
+  atom,
+  property,
+  space,
+  theorem,
+  trait,
+} from '@/__test__/factories'
+import type { Formula, SerializedTheorem } from '@pi-base/core'
+
+type SetupParams = {
+  initial?: Deduction.State
+  spaces?: Space[]
+  properties?: Property[]
+  theorems?: SerializedTheorem[]
+  traits?: Trait[]
+}
+
+describe(Deduction.create, () => {
+  let addedTraits: Trait[] = []
+
+  function addTraits(traits: Trait[]) {
+    addedTraits.push(...traits)
+  }
+
+  function setup(args: Partial<SetupParams> = {}) {
+    addedTraits = []
+
+    const spaces = writable(Collection.byId(args.spaces || []))
+    const properties = Collection.byId(args.properties || [])
+    const theorems = writable(Theorems.build(args.theorems || [], properties))
+    const traits = writable(
+      Traits.build(args.traits || [], get(spaces), properties),
+    )
+
+    return Deduction.create(args.initial, spaces, traits, theorems, addTraits)
+  }
+
+  it('should initialize with spaces if no initial state provided', () => {
+    const store = setup({
+      spaces: [space({ id: 1 }), space({ id: 2 })],
+    })
+    const state = get(store)
+
+    expect(state.all).toEqual(new Set([1, 2]))
+    expect(state.checked).toEqual(new Set())
+  })
+
+  it('should run deductions and add new traits', async () => {
+    const store = setup({
+      spaces: [space({ id: 1 }), space({ id: 2 })],
+      properties: [
+        property({ id: 1 }),
+        property({ id: 2 }),
+        property({ id: 3 }),
+      ],
+      traits: [
+        trait({
+          space: 1,
+          property: 1,
+          value: true,
+        }),
+        trait({
+          space: 2,
+          property: 3,
+          value: false,
+        }),
+      ],
+      theorems: [
+        theorem({
+          id: 1,
+          when: { kind: 'atom', property: 1, value: true },
+          then: { kind: 'atom', property: 2, value: true },
+        }),
+        theorem({
+          id: 2,
+          when: { kind: 'atom', property: 2, value: true },
+          then: { kind: 'atom', property: 3, value: true },
+        }),
+      ],
+    })
+
+    const stores: Deduction.State[] = []
+    store.subscribe($store => stores.push($store))
+
+    await store.run()
+
+    // FIXME: this documents the current behavior, but it's surprising that we're
+    // getting duplicated entries.
+    expect(stores.map(({ checking, checked }) => [checking, checked])).toEqual([
+      [undefined, new Set()],
+      [undefined, new Set()],
+      ['Space 1', new Set()],
+      ['Space 1', new Set([1])],
+      ['Space 1', new Set([1])],
+      ['Space 2', new Set([1])],
+      ['Space 2', new Set([1, 2])],
+      ['Space 2', new Set([1, 2])],
+      ['Space 2', new Set([1, 2])],
+    ])
+
+    expect(
+      addedTraits.map(({ space, property, value }) => [space, property, value]),
+    ).toEqual([
+      [1, 2, true],
+      [1, 3, true],
+      [2, 2, false],
+      [2, 1, false],
+      [2, 2, false],
+      [2, 1, false],
+    ])
+  })
+
+  it('should mark spaces as checked after deduction', async () => {
+    const store = setup({
+      spaces: [space({ id: 1 })],
+      properties: [property({ id: 1 })],
+      traits: [
+        trait({
+          space: 1,
+          property: 1,
+          value: true,
+        }),
+      ],
+    })
+
+    await store.checked(1)
+
+    const state = get(store)
+    expect(state.checked).toContain(1)
+  })
+
+  it('should handle contradictions', async () => {
+    // Create a setup that will lead to contradiction
+    const store = setup({
+      spaces: [space({ id: 1 })],
+      properties: [property({ id: 1 }), property({ id: 2 })],
+      traits: [
+        trait({
+          space: 1,
+          property: 1,
+          value: true,
+        }),
+        trait({
+          space: 1,
+          property: 2,
+          value: false,
+        }),
+      ],
+      theorems: [
+        theorem({
+          id: 1,
+          when: { kind: 'atom', property: 1, value: true },
+          then: { kind: 'atom', property: 2, value: true },
+        }),
+      ],
+    })
+
+    await store.checked(1)
+
+    const state = get(store)
+    expect(state.contradiction?.theorems).toContain(1)
+  })
+
+  it('should reset state when run with reset=true', async () => {
+    const store = setup({
+      spaces: [space({ id: 1 }), space({ id: 2 })],
+      initial: {
+        checked: new Set([3]),
+        all: new Set([1, 2, 3]),
+      },
+    })
+
+    await store.run(true)
+
+    const state = get(store)
+    expect(state.checked).toEqual(new Set([1, 2]))
+    expect(state.all).toEqual(new Set([1, 2]))
+  })
+
+  it('should prove theorems correctly', () => {
+    const store = setup({
+      properties: [
+        property({ id: 1 }),
+        property({ id: 2 }),
+        property({ id: 3 }),
+      ],
+      theorems: [
+        theorem({
+          id: 1,
+          when: { kind: 'atom', property: 1, value: true },
+          then: { kind: 'atom', property: 2, value: true },
+        }),
+        theorem({
+          id: 2,
+          when: { kind: 'atom', property: 2, value: true },
+          then: { kind: 'atom', property: 3, value: false },
+        }),
+      ],
+    })
+
+    const proof = store.prove({
+      when: {
+        kind: 'atom',
+        property: property({ id: 1 }),
+        value: true,
+      },
+      then: {
+        kind: 'atom',
+        property: property({ id: 3 }),
+        value: false,
+      },
+    } as any)
+
+    expect((proof as Theorem[]).map(t => t.id)).toEqual([1, 2])
+  })
+
+  it('should handle multiple spaces in deduction', async () => {
+    const store = setup({
+      spaces: [space({ id: 1 }), space({ id: 2 })],
+      properties: [property({ id: 1 })],
+      traits: [
+        trait({
+          space: 1,
+          property: 1,
+          value: true,
+        }),
+        trait({
+          space: 2,
+          property: 1,
+          value: false,
+        }),
+      ],
+    })
+
+    await store.run()
+
+    expect(get(store).checked).toEqual(new Set([1, 2]))
+  })
+
+  it('should update all spaces set when new spaces are added', () => {
+    const spacesStore = writable(Collection.byId([space({ id: 1 })]))
+
+    const store = Deduction.create(
+      undefined,
+      spacesStore,
+      writable(Traits.empty()),
+      writable(new Theorems()),
+      addTraits,
+    )
+
+    // Add a new space
+    spacesStore.set(Collection.byId([space({ id: 1 }), space({ id: 2 })]))
+    store.run()
+
+    const state = get(store)
+    expect(state.all).toContain(1)
+    expect(state.all).toContain(2)
+  })
+
+  describe('disprove function', () => {
+    it('should disprove a formula using theorems', () => {
+      const t1 = theorem({
+        id: 1,
+        when: { kind: 'atom', property: 1, value: true },
+        then: { kind: 'atom', property: 2, value: true },
+      })
+
+      const properties = Collection.byId([
+        property({ id: 1 }),
+        property({ id: 2 }),
+      ])
+
+      const theoremsStore = writable(Theorems.build([t1], properties))
+
+      const formula: Formula<Property> = and(
+        atom(property({ id: 1 }), true),
+        atom(property({ id: 2 }), false),
+      )
+
+      expect(
+        (Deduction.disprove(theoremsStore, formula) as Theorem[]).map(
+          t => t.id,
+        ),
+      ).toEqual([1])
+    })
+  })
+})

--- a/packages/viewer/src/stores/deduction.ts
+++ b/packages/viewer/src/stores/deduction.ts
@@ -26,11 +26,12 @@ export type State = {
     properties: number[]
     theorems: number[]
   }
+  checking?: string
 }
 
 export type Store = Readable<State> & {
   checked(spaceId: number): Promise<void>
-  run(reset?: boolean): void
+  run(reset?: boolean): Promise<void>
   prove(theorem: Theorem): Theorem[] | 'tautology' | null
 }
 
@@ -87,7 +88,7 @@ export function create(
     setTimeout(run, 0)
   })
 
-  function run(reset = false) {
+  function run(reset = false): Promise<void> {
     if (reset) {
       store.set(initialize(read(spaces)))
     }
@@ -108,7 +109,7 @@ export function create(
       }
     })
 
-    eachTick(unchecked, (s: Space, halt: () => void) => {
+    return eachTick(unchecked, (s: Space, halt: () => void) => {
       store.update(state => ({ ...state, checking: s.name }))
 
       const map = new Map(

--- a/packages/viewer/vite.config.js
+++ b/packages/viewer/vite.config.js
@@ -17,6 +17,9 @@ export default defineConfig({
   test: {
     include: ['src/**/*.{test,spec}.{js,ts}'],
     coverage: {
+      provider: 'v8',
+      reporter: ['text', 'json', 'html', 'lcov', 'clover'],
+      reportsDirectory: './coverage',
       lines: 82.99,
       branches: 85.71,
       statements: 82.99,


### PR DESCRIPTION
The major addition here is tests covering the integration between the top-level app Context initialization and the Store loading from the Local<Prestore> and Gateway. These can be expanded, but offer a decent enough regression suite for the top-level loading behavior.

This commit includes a few minor QoL additions:

- setup vscode / copilot support for running tests via tasks
- remove an unused import
- make some parameters optional when a sensible default is available