### PR TITLE
fix: formula parse for formula begins with `(`

### DIFF
--- a/packages/core/src/Formula.ts
+++ b/packages/core/src/Formula.ts
@@ -180,28 +180,18 @@ export function evaluate<T, V extends boolean | null = boolean>(
 }
 
 export function parse(q?: string): Formula<string, null> | undefined {
-  if (!q) {
-    return
-  }
-
-  let parsed
   try {
-    // eslint-disable-next-line
-    parsed = _parse(q)
-  } catch {
-    if (q && q.startsWith('(')) {
-      return
-    } else {
-      return parse('(' + q + ')')
+    if (q) {
+      // eslint-disable-next-line
+      return fromJSON(_parse(q) as Serialized)
     }
-  }
-
-  return fromJSON(parsed as any)
+  } catch {}
 }
 
 type Serialized<X = never> =
   | { and: Serialized[] }
   | { or: Serialized[] }
+  | { inner: Serialized }
   | { property: string; value: boolean | X }
   | Record<string, boolean | X>
 
@@ -210,6 +200,8 @@ export function fromJSON(json: Serialized): Formula<string, null> {
     return and<string, null>(...json.and.map(fromJSON))
   } else if ('or' in json && typeof json.or === 'object') {
     return or<string, null>(...json.or.map(fromJSON))
+  } else if ('inner' in json && typeof json.inner === 'object') {
+    return fromJSON(json.inner)
   } else if ('property' in json && typeof json.property === 'string') {
     return atom<string, null>(json.property, json.value)
   }

--- a/packages/core/src/Formula.ts
+++ b/packages/core/src/Formula.ts
@@ -183,7 +183,7 @@ export function parse(q?: string): Formula<string, null> | undefined {
   try {
     if (q) {
       // eslint-disable-next-line
-      return fromJSON(_parse(q) as Serialized)
+      return fromJSON(_parse(`(${q})`) as Serialized)
     }
   } catch {}
 }

--- a/packages/core/src/Formula/Grammar.pegjs
+++ b/packages/core/src/Formula/Grammar.pegjs
@@ -1,4 +1,4 @@
-Formula "formula" = And / Or / Atom
+Formula "formula" = And / Or / Wrapped / Atom
 
 _ "whitespace" = [ \t\n\r]*
 
@@ -8,6 +8,10 @@ And = _ "(" _ head:Formula tail:(_ Conjunction _ Formula)+ _ ")" _ {
 
 Or = _ "(" _ head:Formula tail:(_ Disjunction _ Formula)+ _ ")" _ {
   return { or: [head].concat(tail.map((item: unknown[]) => item[3])) }
+}
+
+Wrapped = _ "(" _ inner:Formula _ ")" _ {
+  return { inner }
 }
 
 Atom = mod:Modifier? _ prop:Property {

--- a/packages/core/test/Formula.test.ts
+++ b/packages/core/test/Formula.test.ts
@@ -11,7 +11,7 @@ import {
   or,
   map,
   mapProperty,
-  parse as parseRaw,
+  parse,
   properties,
   render,
   toJSON,
@@ -24,8 +24,6 @@ const compound = and<string>(
 )
 
 const render_ = (f: Formula<string>) => render(f, (p: string) => p)
-
-const parse = (q: string) => parseRaw(`(${q})`)
 
 describe('Formula', () => {
   describe('structure', () => {
@@ -189,6 +187,7 @@ describe('parsing', () => {
   })
 
   it('handles empty strings', () => {
+    expect(parse()).toBeUndefined()
     expect(parse('')).toBeUndefined()
   })
 

--- a/packages/core/test/Formula.test.ts
+++ b/packages/core/test/Formula.test.ts
@@ -11,7 +11,7 @@ import {
   or,
   map,
   mapProperty,
-  parse,
+  parse as parseRaw,
   properties,
   render,
   toJSON,
@@ -24,6 +24,8 @@ const compound = and<string>(
 )
 
 const render_ = (f: Formula<string>) => render(f, (p: string) => p)
+
+const parse = (q: string) => parseRaw(`(${q})`)
 
 describe('Formula', () => {
   describe('structure', () => {
@@ -187,8 +189,13 @@ describe('parsing', () => {
   })
 
   it('handles empty strings', () => {
-    expect(parse()).toBeUndefined()
     expect(parse('')).toBeUndefined()
+  })
+
+  it('resolves #226', () => {
+    expect(parse('(T1 | T2) & T3')).toEqual(
+      and(or(atom('T1'), atom('T2')), atom('T3')),
+    )
   })
 })
 

--- a/packages/viewer/src/components/Shared/Formula/Input/store.ts
+++ b/packages/viewer/src/components/Shared/Formula/Input/store.ts
@@ -104,7 +104,7 @@ function resolve(
   index: Fuse<Property>,
   str: string,
 ): Formula<Property, null> | undefined {
-  const parsed = F.parse(`(${str})`)
+  const parsed = F.parse(str)
   if (!parsed) {
     return
   }

--- a/packages/viewer/src/components/Shared/Formula/Input/store.ts
+++ b/packages/viewer/src/components/Shared/Formula/Input/store.ts
@@ -104,7 +104,7 @@ function resolve(
   index: Fuse<Property>,
   str: string,
 ): Formula<Property, null> | undefined {
-  const parsed = F.parse(str)
+  const parsed = F.parse(`(${str})`)
   if (!parsed) {
     return
   }


### PR DESCRIPTION
The original code https://github.com/pi-base/web/blob/72355584f23608b21f3c062c2f54425b33f7c4ce/packages/core/src/Formula.ts#L192-L196 use the logic that, if `q` starts with `(` then regard `q` as a whole atom. But this may be fail on something like `(T1 | T2) & T3`, as [following](https://topology.pi-base.org/spaces?q=%28T1+%7C+T2%29+%26+T3):

<img width="1135" alt="(T1 | T2) & T3 fails" src="https://github.com/user-attachments/assets/42f8a26f-fba5-41ff-b6ee-ecb8c3d69425" />

The simplest fix is just modify the peggy syntax, adding a new item named `Wrapped` (atom) just wrap an formula with single “(”“)”, e.g., `(T1)`, and it works.

<img width="1139" alt="(T1 | T2) & T3 works" src="https://github.com/user-attachments/assets/35ab05dd-1f49-458b-b442-c19d528bd30b" />