### PR TITLE
fix: disappear emphasizedProperties

### DIFF
--- a/packages/viewer/src/components/Shared/Formula/Atom.svelte
+++ b/packages/viewer/src/components/Shared/Formula/Atom.svelte
@@ -7,7 +7,7 @@
   export let value: Atom<Property>
   export let link: boolean = true
   export let emphasizedProperties: Set<Property> = new Set()
-  let emphasized = emphasizedProperties.has(value.property)
+  $: emphasized = emphasizedProperties.has(value.property)
 </script>
 
 {value.value === null ? '?' : value.value ? '' : '¬'}{#if link}<Link.Property


### PR DESCRIPTION
https://github.com/user-attachments/assets/e32c0447-4673-4e79-89c7-4b951c25ef31

Fix the issue of the disappearance of “Partition topology” highlight.
