### PR TITLE
perf(ci): trim redundant install and unneeded build scripts from CF builds

### DIFF
--- a/bin/build
+++ b/bin/build
@@ -14,13 +14,18 @@ export VITE_VERSION="${WORKERS_CI_COMMIT_SHA:-${CF_PAGES_COMMIT_SHA:-$(git rev-p
 export VITE_SITE="${VITE_SITE:-topology}"
 echo "Building site '${VITE_SITE}' (branch=${VITE_BRANCH}, version=${VITE_VERSION})"
 
-# Pages' build image does not include pnpm, but Workers Builds does (detected
-# from .tool-versions). Only install it when missing, otherwise the global
-# install errors with EEXIST. Install packages somewhere that Cloudflare caches.
+# Workers Builds (and the GitHub workflows) run `pnpm install` before invoking
+# this script, so only install when dependencies are actually missing — e.g.
+# running this script on a clean local checkout. This skips a redundant second
+# install on CI, which was the bulk of each build's wall time.
 #
-# See https://community.cloudflare.com/t/add-pnpm-to-pre-installed-cloudflare-pages-tools/288514/3
-command -v pnpm >/dev/null 2>&1 || npm install -g pnpm
-pnpm install --store=node_modules/.pnpm-store
+# Don't pass `--store=node_modules/.pnpm-store`: relocating the store forces pnpm
+# to recreate node_modules and fragments it from the CI auto-install's store,
+# defeating the dependency cache (every package re-downloads).
+if [ ! -d node_modules ]; then
+  command -v pnpm >/dev/null 2>&1 || npm install -g pnpm
+  pnpm install --frozen-lockfile
+fi
 
 cd ./packages/core
 pnpm run build

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,9 +1,12 @@
 packages:
   - packages/*
+# Only run install/build scripts for dependencies the deploy build needs.
+# Excluded on purpose (kept lean so CI installs don't do unnecessary work):
+#   - cypress: binary download (~20s); only the e2e workflow runs it, and that
+#     workflow installs the binary explicitly via `cypress install`.
+#   - keytar / @vscode/vsce-sign: native builds for the vscode extension's
+#     `vsce publish`; not used by the viewer build, the viewer runtime, or tests.
 allowBuilds:
   '@sveltejs/kit': true
-  '@vscode/vsce-sign': true
-  cypress: true
   esbuild: true
-  keytar: true
   svelte-preprocess: true


### PR DESCRIPTION
## Why

Each Cloudflare Workers build was doing substantially more work than needed, and this multiplies across the two git-connected Workers (`pi-base-topology` + `pi-base-graphs`) that build on every push.

Two issues, both visible in the build logs:

1. **Dependencies were installed twice.** Workers Builds auto-runs `pnpm install --frozen-lockfile` before the build command, but `bin/build` then ran a *second* `pnpm install --store=node_modules/.pnpm-store`. The relocated store forced node_modules to be recreated (`Recreating /opt/buildhome/repo/node_modules`) and fragmented it from the auto-install's store, so even warm builds re-downloaded every package (`reused 0`).

2. **Install ran build scripts the deploy doesn't need.** `allowBuilds` approved Cypress (binary download, ~20s), keytar and `@vscode/vsce-sign` (native builds) — none of which the viewer build or runtime touches.

## What changed

- **`bin/build`**: only install when `node_modules` is genuinely missing (clean local checkout); drop the `--store` relocation so the CI dependency cache is actually reused.
- **`pnpm-workspace.yaml`**: remove `cypress`, `keytar`, `@vscode/vsce-sign` from `allowBuilds`. Kept `@sveltejs/kit`, `esbuild`, `svelte-preprocess`, which the viewer build needs.

## Safety / blast radius

- CF-only + install-script changes; the GitHub `test` and `e2e` workflows are unaffected.
- The **e2e** workflow already installs the Cypress binary explicitly (`pnpm --filter viewer exec cypress install`) and notes the postinstall is skipped on warm cache.
- **keytar/vsce-sign** are vscode `vsce publish` deps — nothing in `vscode/src` imports keytar, and the unit-test workflow (`--recursive test:cov`) skips vscode (no `test:cov` script).

## Expected impact

Removes the redundant ~23s install and lets the remaining install hit the warm cache instead of re-downloading — roughly **~1 min off each build**, on both Workers, every push.

## Verifying

On the next build, the log should show: no second `pnpm install`; cypress/keytar/vsce-sign in the *"Ignored build scripts"* line; and the auto-install reporting a meaningful `reused N`.

## Not included (intentionally deferred)

- Restricting builds to production branch + PRs.
- Deduplicating the two Workers building identical output (dashboard/API config).
- Runtime SSR cost reduction.