### PR TITLE
perf(viewer): deduce spaces lazily instead of the full database in SSR

### DIFF
--- a/packages/viewer/src/debug.ts
+++ b/packages/viewer/src/debug.ts
@@ -47,9 +47,23 @@ export type ServerEvent =
       // deduction work, since the eager run finishes after the SSR response is
       // sent, so a completion-time count is dropped. `reset` marks a full re-run
       // (e.g. from a refresh) vs an incremental top-up.
+      //
+      // Client-only after the lazy-deduction change: the full run no longer
+      // fires during SSR, so this should disappear from runtime logs entirely
+      // (see `deduce_space`).
       evt: 'deduce_run'
       planned: number
       reset: boolean
+    }
+  | {
+      // One per space deduced on demand. SSR now proves only the single space a
+      // page needs, so a page render should emit exactly one of these instead of
+      // a `deduce_run` over the whole database. `derived` is the trait count
+      // proved (0 on a `contradiction`).
+      evt: 'deduce_space'
+      space: number
+      derived: number
+      contradiction: boolean
     }
 
 // Emit one structured Workers Logs event. We log the *object* (not a JSON

--- a/packages/viewer/src/stores/deduction.test.ts
+++ b/packages/viewer/src/stores/deduction.test.ts
@@ -97,17 +97,14 @@ describe(Deduction.create, () => {
 
     await store.run()
 
-    // FIXME: this documents the current behavior, but it's surprising that we're
-    // getting duplicated entries.
+    // Each space is deduced exactly once: the store advances to "checking" the
+    // space, then records it as checked, with no duplicate passes.
     expect(stores.map(({ checking, checked }) => [checking, checked])).toEqual([
       [undefined, new Set()],
       [undefined, new Set()],
       ['Space 1', new Set()],
       ['Space 1', new Set([1])],
-      ['Space 1', new Set([1])],
       ['Space 2', new Set([1])],
-      ['Space 2', new Set([1, 2])],
-      ['Space 2', new Set([1, 2])],
       ['Space 2', new Set([1, 2])],
     ])
 
@@ -116,8 +113,6 @@ describe(Deduction.create, () => {
     ).toEqual([
       [1, 2, true],
       [1, 3, true],
-      [2, 2, false],
-      [2, 1, false],
       [2, 2, false],
       [2, 1, false],
     ])

--- a/packages/viewer/src/stores/deduction.ts
+++ b/packages/viewer/src/stores/deduction.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment'
 import { type Readable, writable } from 'svelte/store'
 import {
   ImplicationIndex,
@@ -85,9 +86,67 @@ export function create(
   theorems.subscribe($theorems => {
     implications = indexTheorems($theorems)
 
-    // Ensure that the trait store is updated before deductions run
-    setTimeout(run, 0)
+    // The eager full-database prover only makes sense for the interactive
+    // client. During SSR it re-derives every space on each request and dominates
+    // Worker CPU, so we deduce individual spaces lazily via `checked` instead.
+    if (browser) {
+      // Ensure that the trait store is updated before deductions run
+      setTimeout(run, 0)
+    }
   })
+
+  // Deduce a single space, deriving its traits from the asserted ones (or
+  // recording a contradiction). Idempotent: already-checked spaces are skipped.
+  function deduceSpace(space: Space): void {
+    const state = read(store)
+    if (state.contradiction || state.checked.has(space.id)) {
+      return
+    }
+
+    store.update(s => ({ ...s, checking: space.name }))
+
+    const map = new Map(
+      read(traits)
+        .forSpace(space)
+        .map(([p, t]) => [p.id, t.value]),
+    )
+    const result = deduceTraits(implications, map)
+
+    if (result.kind === 'contradiction') {
+      store.update(s => ({ ...s, contradiction: result.contradiction }))
+      serverLog({
+        evt: 'deduce_space',
+        space: space.id,
+        derived: 0,
+        contradiction: true,
+      })
+      return
+    }
+
+    const newTraits: DeducedTrait[] = result.derivations
+      .all()
+      .map(({ property, value, proof }) => ({
+        asserted: false,
+        space: space.id,
+        property,
+        value,
+        proof,
+      }))
+
+    addTraits(newTraits)
+
+    store.update(s => ({
+      ...s,
+      checked: new Set([...s.checked, space.id]),
+    }))
+
+    serverLog({
+      evt: 'deduce_space',
+      space: space.id,
+      derived: newTraits.length,
+      contradiction: false,
+    })
+  }
 
   function run(reset = false): Promise<void> {
     if (reset) {
@@ -102,13 +161,7 @@ export function create(
     }))
 
     const checked = read(store).checked
-
-    const unchecked: Space[] = []
-    allSpaces.forEach(s => {
-      if (!checked.has(s.id)) {
-        unchecked.push(s)
-      }
-    })
+    const unchecked = allSpaces.filter(s => !checked.has(s.id))
 
     // Log the planned work *synchronously*, before the async loop. On the eager
     // SSR model the loop finishes after the response is sent (the page resolves
@@ -118,37 +171,10 @@ export function create(
     serverLog({ evt: 'deduce_run', planned: unchecked.length, reset })
 
     return eachTick(unchecked, (s: Space, halt: () => void) => {
-      store.update(state => ({ ...state, checking: s.name }))
-
-      const map = new Map(
-        read(traits)
-          .forSpace(s)
-          .map(([p, t]) => [p.id, t.value]),
-      )
-      const result = deduceTraits(implications, map)
-
-      if (result.kind === 'contradiction') {
-        store.update(s => ({ ...s, contradiction: result.contradiction }))
+      deduceSpace(s)
+      if (read(store).contradiction) {
         halt()
-        return
       }
-
-      const newTraits: DeducedTrait[] = result.derivations
-        .all()
-        .map(({ property, value, proof }) => ({
-          asserted: false,
-          space: s.id,
-          property,
-          value,
-          proof,
-        }))
-
-      addTraits(newTraits)
-
-      store.update(state => ({
-        ...state,
-        checked: new Set([...state.checked, s.id]),
-      }))
     })
   }
 
@@ -156,6 +182,12 @@ export function create(
     subscribe: store.subscribe,
     run,
     checked(spaceId: number) {
+      // Deduce on demand so a single SSR page render only proves the space it
+      // needs, rather than blocking on a full-database background run.
+      const space = read(spaces).find(spaceId)
+      if (space) {
+        deduceSpace(space)
+      }
       return subscribeUntil(
         store,
         state => state.checked.has(spaceId) || !!state.contradiction,

--- a/packages/viewer/src/stores/index.ts
+++ b/packages/viewer/src/stores/index.ts
@@ -1,3 +1,4 @@
+import { browser } from '$app/environment'
 import { type SerializedTheorem } from '@pi-base/core'
 import type * as Gateway from '@/gateway'
 import {
@@ -81,7 +82,11 @@ export function create(pre: Prestore, gateway: Gateway.Sync): Store {
     if (result) {
       set(result.properties, result.spaces, result.theorems, result.traits)
 
-      deduction.run(true)
+      // Eager full-database deduction is client-only; during SSR individual
+      // spaces are deduced lazily on demand (see stores/deduction.ts).
+      if (browser) {
+        deduction.run(true)
+      }
 
       return {
         etag: result.etag,


### PR DESCRIPTION
## What & why

The universal layout load runs during SSR, and `refresh()` ran the full deduction engine over **every** space on each request — then the client discarded it and recomputed the same thing after hydration. One logged invocation spent **440 ms of CPU** rendering a single static reference page. Only 3 routes are prerendered, so every detail page (exactly what crawlers and deep links hit) paid this.

Gate the eager full-database deduction to the browser, and have `checked(spaceId)` deduce only the space it needs, on demand — so SSR of the trait page still renders the data it references. Side effect: removes the duplicate deduction passes the old test documented as a FIXME.

## Instrumentation

Adds a `deduce_space` Workers Logs event (space id + derived count). After this change an SSR page render emits exactly one `deduce_space` (the requested space), and `deduce_run` (the full-database pass) disappears from runtime logs.

## Tradeoff

SSR'd space pages show only **asserted** traits in the initial HTML; deduced ones fill in after hydration (unchanged from how the client already worked). If SEO on derived traits matters, prerendering all routes is the follow-up.

## Validation

- [x] `pnpm --filter viewer tsc` and `validate` (svelte-check) — clean
- [x] `pnpm --filter viewer test` — 70 passed, 5 todo (the FIXME duplicate-pass assertions are gone)
- [x] `VITE_SITE=topology pnpm --filter viewer build`

**Manual deploy + telemetry check** (topology worker `pi-base-topology`):

1. `VITE_SITE=topology pnpm --filter viewer build`
2. `pnpm --filter viewer cf:deploy:topology`  (= `wrangler deploy --env topology`)
3. GET a non-prerendered `/spaces/<id>/properties/<id>` page.
4. In Workers Logs / observability:
   - **Expect:** exactly one `deduce_space` per render (the requested space), and **no** `deduce_run` from SSR invocations.
   - Compare the platform `cpuTimeMs` on the detail routes (`request.routeId`) before vs after: should drop from ~440 ms toward low tens of ms.

## Reviewing

Easiest commit-by-commit; base is #254.
